### PR TITLE
test: add format-cspell-json pre-commit hook

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -1,3 +1,8 @@
 {
-  "words": ["chmln", "ctcache", "CTCACHE", "mapfile"]
+  "words": [
+    "chmln",
+    "CTCACHE",
+    "ctcache",
+    "mapfile"
+  ]
 }

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,4 +44,9 @@ repos:
       - id: shfmt
         args: [-w, -s, -i=4]
 
+  - repo: https://github.com/autowarefoundation/autoware-spell-check-dict
+    rev: e9d756af3ac14bacd5c9cea188d47b39d3160f53
+    hooks:
+      - id: format-cspell-json
+
 exclude: .svg

--- a/.prettierignore
+++ b/.prettierignore
@@ -4,3 +4,4 @@
 
 *.param.yaml
 *.rviz
+.cspell.json


### PR DESCRIPTION
Use the published hook from autoware-spell-check-dict to sort and format .cspell.json.

**Note**: Confirm the [contribution guidelines](https://autowarefoundation.github.io/autoware-documentation/main/contributing/) before submitting a pull request.

Click the `Preview` tab and select a PR template:

- [Standard change](?expand=1&template=standard-change.md)
- [Small change](?expand=1&template=small-change.md)

**Do NOT send a PR with this description.**
